### PR TITLE
Add equality check for value objects by reflection

### DIFF
--- a/core/Wrapperizer.Domain.Abstractions/IgnoreMemberForValueObjectAttribute.cs
+++ b/core/Wrapperizer.Domain.Abstractions/IgnoreMemberForValueObjectAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Wrapperizer.Domain.Abstractions
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class IgnoreMemberForValueObjectAttribute : Attribute
+    {
+    }
+}

--- a/core/Wrapperizer.Domain.Abstractions/ValueObject.cs
+++ b/core/Wrapperizer.Domain.Abstractions/ValueObject.cs
@@ -1,15 +1,29 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Security.Principal;
 
 namespace Wrapperizer.Domain.Abstractions
 {
+
+
     /// <summary>
     /// <see cref="https://enterprisecraftsmanship.com/posts/value-object-better-implementation/"/>
     /// </summary>
-    public abstract class ValueObject<T> 
+    public abstract class ValueObject<T>
         where T : ValueObject<T>
     {
-        protected abstract IEnumerable<object> GetEqualityComponents();
+        protected virtual IEnumerable<object> GetEqualityComponents()
+        {
+            var props = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(prop => !Attribute.IsDefined(prop, typeof(IgnoreMemberForValueObjectAttribute)));
+
+            foreach (var prop in props)
+            {
+                yield return prop.GetValue(this, null);
+            }
+        }
 
         public override bool Equals(object obj)
         {


### PR DESCRIPTION
```cs
// Equality check by reflection as a default option but overridable

protected virtual IEnumerable<object> GetEqualityComponents()
{
    var props = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
        .Where(prop => !Attribute.IsDefined(prop, typeof(IgnoreMemberForValueObjectAttribute)));

    foreach (var prop in props)
    {
        yield return prop.GetValue(this, null);
    }
}

// An attribute for ignoring some members for the equality check

[AttributeUsage(AttributeTargets.Property)]
public class IgnoreMemberForValueObjectAttribute : Attribute
{
}
```